### PR TITLE
My previous change errored out when no -P option was given

### DIFF
--- a/files/usr/sbin/zfstx
+++ b/files/usr/sbin/zfstx
@@ -76,8 +76,8 @@ remote_fs=$(echo "$1" | cut -d':' -f 2)
 local_fs=$2
 
 # Check dependencies
-which mbuffer > /dev/null 2>&1 || { echo "ERROR: 'mbuffer' is not installed."; exit 1; }
-[ -z "$pigz" ] && which pigz > /dev/null 2>&1 || { echo "ERROR: 'pigz' is not installed. Install it, or use --no-pigz."; exit 1; }
+[ $( which mbuffer > /dev/null; echo "$?" ) -eq 0 ] || { echo "ERROR: 'mbuffer' is not installed.cha"; exit 1; }
+[ -n "$pigz" ] || [ $( which pigz > /dev/null; echo "$?" ) -eq 0 ] || { echo "ERROR: 'pigz' is not installed. Install it, or use --no-pigz."; exit 1; }
 
 # Check mandatory options
 [ -z "$remote_host" -o -z "$remote_fs" -o -z "$local_fs" ] && { usage; exit 1; }


### PR DESCRIPTION
You committed a previous change of mine which checks whether "pigz" variable is non-zero.  It turns out that the conditional expression now errors out on the second conditional now.  There may be a more elegant way to handle, or I may not understand your intent, but here I check the exist status of the "which" command to determine whether to continue.  I also changed the mbuffer line to make uniform.